### PR TITLE
Fix race conditions at startup.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends: debhelper (>= 9.0.0),
   qtbase5-dev-tools,
   libqt5bluetooth5,
   qtconnectivity5-dev,
-  libnymea-networkmanager-dev,
+  libnymea-networkmanager-dev (>= 0.3.0),
   libnymea-gpio-dev
 Standards-Version: 3.9.7
 

--- a/nymea-networkmanager/core.h
+++ b/nymea-networkmanager/core.h
@@ -36,8 +36,8 @@
 #include "nymeadservice.h"
 #include "nymea-gpio/gpiobutton.h"
 #include "bluetooth/bluetoothserver.h"
-#include "nymea-networkmanager/networkmanager.h"
-#include "nymea-networkmanager/bluetooth/bluetoothserver.h"
+#include "networkmanager.h"
+#include "bluetooth/bluetoothserver.h"
 
 class Core : public QObject
 {
@@ -95,7 +95,6 @@ private:
     QString m_advertiseName;
     QString m_platformName;
     int m_advertisingTimeout = 60;
-    bool m_initRunning = true;
     int m_buttonGpio = -1;
 
     void evaluateNetworkManagerState(NetworkManager::NetworkManagerState state);
@@ -103,8 +102,6 @@ private:
 private slots:
     void startService();
     void stopService();
-
-    void postRun();
 
     void onAdvertisingTimeout();
 


### PR DESCRIPTION
Rework the setup sequence to not rely on timers anymore but instead
always react to wifi state changes only.

Fixes #29