### PR TITLE
Don't print a warning when nymead is not running.

### DIFF
--- a/nymea-networkmanager/nymeadservice.cpp
+++ b/nymea-networkmanager/nymeadservice.cpp
@@ -71,7 +71,7 @@ bool NymeadService::available() const
 void NymeadService::enableBluetooth(bool enable)
 {
     if (!m_nymeadHardwareBluetoothInterface) {
-        qCWarning(dcNymeaService()) << "Could not enable/disable bluetooth hardware resource. D-Bus interface not available.";
+        qCDebug(dcNymeaService()) << "Could not enable/disable bluetooth hardware resource. D-Bus interface not available.";
         return;
     }
 


### PR DESCRIPTION
Most users use this standalone and they keep on blaming this message
if something isn't working while it is in fact not a problem at all
if this isn't around.