### PR TITLE
Fix systemd targets

### DIFF
--- a/systemd/nymea-networkmanager.service
+++ b/systemd/nymea-networkmanager.service
@@ -2,7 +2,7 @@
 Description=Daemon for nymea to configure wifi network using a Bluetooth LE connection
 Documentation=https://github.com/nymea/nymea-networkmanager
 Requires=bluetooth.target bluetooth.service NetworkManager.service
-After=bluetooth.service bluetooth.target network.target multi-user.target
+After=bluetooth.service bluetooth.target network.target
 
 [Service]
 ExecStart=/usr/bin/nymea-networkmanager -d
@@ -12,4 +12,4 @@ Restart=on-failure
 Type=simple
 
 [Install]
-WantedBy=graphical.target
+WantedBy=multi-user.target


### PR DESCRIPTION
For one, this should not be installed into the graphical target, as its main purpose is indeed to set up headless systems where the graphical.target may not even be started.

Secondly, having set After=multi-user.target may cause it to not start at all if another broken service in the multi-user.target fails to start and thus the multi-user.target may not complete.
